### PR TITLE
Fix dir creation when cocci_cache is missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -282,7 +282,7 @@ func (s *server) newPatch(body []byte, drbdversion string) ([]byte, error) {
 
 	// '_' is never an existing md5sum
 	cocciPath := filepath.Join(dir, intarballName, "drbd", "drbd-kernel-compat", "cocci_cache", "_")
-	if err := os.Mkdir(cocciPath, 0755); err != nil {
+	if err := os.MkdirAll(cocciPath, 0755); err != nil {
 		return nil, fmt.Errorf("Could not create cocci dir: %v", err)
 	}
 


### PR DESCRIPTION
When drbd tarball created from github source code, it does not contain any patches.
spaas binary can't create directory `cocci_cache/_`, because `cocci_cache` does not exists:

```
root@cb6f63ef8e10:/# /spaas -addr ":2020" -patchcache /var/cache/saas/patches -tarcache /var/cache/saas/tarballs --debug --keeptmpdir
2022-06-09T22:19:33.381Z	DEBUG	spaas/main.go:170	adding /var/cache/saas/tarballs/drbd-9.1.7.tar.gz to the tarball cache
2022-06-09T22:19:36.182Z	ERROR	spaas/main.go:399	Could not generate patch: Could not create cocci dir: mkdir /tmp/saas3305441620/drbd-9.1.7/drbd/drbd-kernel-compat/cocci_cache/_: no such file or directory	{"type": "error", "remoteAddr": "127.0.0.1:35236", "code": 400}
main.(*server).errorf
	/usr/local/go/spaas/main.go:399
main.(*server).spatchCreate.func1
	/usr/local/go/spaas/main.go:189
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/gorilla/mux.(*Router).ServeHTTP
	/go/pkg/mod/github.com/gorilla/mux@v1.7.3/mux.go:212
main.(*server).ServeHTTP
	/usr/local/go/spaas/main.go:124
net/http.serverHandler.ServeHTTP
	/usr/local/go/src/net/http/server.go:2916
net/http.(*conn).serve
	/usr/local/go/src/net/http/server.go:1966
```